### PR TITLE
Use Oracle extensions for named support

### DIFF
--- a/spring-jdbc-oracle-ojdbc/src/main/java/oracle/jdbc/OraclePreparedStatement.java
+++ b/spring-jdbc-oracle-ojdbc/src/main/java/oracle/jdbc/OraclePreparedStatement.java
@@ -25,9 +25,18 @@ import oracle.sql.TIMESTAMPTZ;
  */
 public interface OraclePreparedStatement extends PreparedStatement {
 
+  // batch support
   void setExecuteBatch(int sendBatchSize) throws SQLException;
   int getExecuteBatch();
   int sendBatch() throws SQLException;
   
+  // named support
+  void setObjectAtName(String parameterName, Object value) throws SQLException;
+  void setObjectAtName(String parameterName, Object value, int targetSqlType) throws SQLException;
+  void setObjectAtName(String parameterName, Object value, int targetSqlType, int scale) throws SQLException;
+  void setNullAtName(String parameterName, int sqlType) throws SQLException;
+  void setNullAtName(String parameterName, int sqlType, String sqlName) throws SQLException;
+  
+  // timestamptz support
   void setTIMESTAMPTZ(int parameterIndex, TIMESTAMPTZ x) throws SQLException;
 }

--- a/spring-jdbc-oracle-ojdbc/src/main/java/oracle/sql/TIMESTAMPTZ.java
+++ b/spring-jdbc-oracle-ojdbc/src/main/java/oracle/sql/TIMESTAMPTZ.java
@@ -19,6 +19,10 @@ package oracle.sql;
  * Dummy {@code TIMESTAMPTZ} interface which avoids a dependency to OJDBC.
  */
 public class TIMESTAMPTZ {
+  
+  public TIMESTAMPTZ(byte[] timestamptz) {
+    super();
+  }
 
   public byte[] toBytes() {
     return new byte[0];


### PR DESCRIPTION
Rewrite `OracleNamedParameterJdbcTemplate` using named parameter support
in `OraclePreparedStatement`.

This has the advantage that all parsing code is gnone. As a disadvantage
all the collections support is now gone too. Also null support is a bit wacky.
Also we only support `MapSqlParameterSource` and `BeanPropertySqlParameterSource`
but `SqlParameterSource` is so badly designed that this can't be helped.
We could in theory try to detect collections and in this case delegate to
super. Note that this would have the same `SqlParameterSource` limitations.
