### PR TITLE
Switch to Official Oracle Coordinates

### DIFF
--- a/spring-jdbc-oracle-integrationtests/pom.xml
+++ b/spring-jdbc-oracle-integrationtests/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <!-- Dependency versions (only used in this module). -->
-    <ojdbc8.version>12.2.0.1</ojdbc8.version>
+    <ojdbc8.version>18.3.0.0</ojdbc8.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <tomcat-jdbc.version>9.0.4</tomcat-jdbc.version>
 
@@ -36,9 +36,15 @@
     </dependency>
 
     <dependency>
-      <groupId>com.oracle</groupId>
+      <groupId>com.oracle.jdbc</groupId>
       <artifactId>ojdbc8</artifactId>
       <version>${ojdbc8.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle.jdbc</groupId>
+          <artifactId>ucp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-dbcp</groupId>


### PR DESCRIPTION
We document using the official Oracle coordinates but don't actually use them.

How to configure the Oracle Maven repository can be learned from these pages:

https://maven.apache.org/guides/mini/guide-encryption.html
https://blogs.oracle.com/dev2dev/get-oracle-jdbc-drivers-and-ucp-from-oracle-maven-repository-without-ides
https://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm#MAVEN9010